### PR TITLE
deb packaging fixes to run rplidar on the drone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,12 @@ ament_target_dependencies(rplidar_client rclcpp sensor_msgs std_srvs rclcpp_comp
 ament_auto_add_executable(rplidar src/rplidar.cpp)
 target_link_libraries(rplidar rplidar_node)
 
-install(TARGETS rplidar_client rplidar rplidar_sdk
+install(TARGETS rplidar_client rplidar
         DESTINATION lib/${PROJECT_NAME})
+
+# On the drone LD_LIBRARY_PATH only available for /opt/ros/foxy/lib
+install(TARGETS rplidar_sdk rplidar_node
+        DESTINATION lib/)
 
 install(DIRECTORY launch rviz config
         DESTINATION share/${PROJECT_NAME})

--- a/config/rplidar.yaml
+++ b/config/rplidar.yaml
@@ -1,7 +1,7 @@
 rplidar:
   ros__parameters:
     serial_port: /dev/ttyUSB0
-    serial_baudrate: 115200
+    serial_baudrate: 256000
     frame_id: laser_frame
     inverted: false
     angle_compensate: true

--- a/launch/rplidar.launch.py
+++ b/launch/rplidar.launch.py
@@ -1,11 +1,11 @@
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 from os import path
-
+import os
 from launch import LaunchDescription
 
-
 def generate_launch_description():
+    DRONE_DEVICE_ID=os.getenv('DRONE_DEVICE_ID')
     return LaunchDescription([
         Node(
             node_name='rplidar',
@@ -13,8 +13,9 @@ def generate_launch_description():
             node_executable='rplidar',
             output='screen',
             parameters=[
-                path.join(get_package_share_directory('rplidar_ros'), 'config',
-                          'rplidar.yaml')
+                path.join(get_package_share_directory('rplidar_ros2'), 'config',
+                          'rplidar.yaml'),
+                {'topic_name': DRONE_DEVICE_ID + '/rplidar/scan'}
             ],
         ),
     ])


### PR DESCRIPTION
Hi @spurnvoj 
There were few problems, running rplidar deb on the drone, here I solved those 
1. moved so file into `/opt/ros/foxy/lib` (it present in `LD_LIBRARY_PATH`, but not the `/opt/ros/foxy/lib/rplidar_ros2`)
2. output topic name is set according to `DRONE_DEVICE_ID`
3. `baudrate` is changed according to lidar we have here. This is questionable change - shall we alternatively change baudrate settings somewhere inside lidar? 