### PR TITLE
Rplidar update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN /packaging/build.sh
 
 FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-3dcb78d
 
-ENTRYPOINT /entrypoint.sh
-
-COPY entrypoint.sh /entrypoint.sh
+# launch file checks env variables SIMULATION and DRONE_TYPE
+# SIMULATION is by default 0. However, it can be set to 1
+# DRONE_TYPE is by default T-DRONE. However, it can be set to HOLYBRO
+ENTRYPOINT exec ros-with-env ros2 launch rplidar_ros2 sensors_launch.py
 
 COPY --from=builder /main_ws/ros-*-rplidar-ros2_*_amd64.deb /rplidar.deb
 

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -1,0 +1,28 @@
+/**:
+  ros__parameters:
+    frame_id: rplidar_frame
+    # serial - specify baudrate and serial port
+    # tcp - specify TCP address and port
+    channel_type: "serial"
+    tcp_ip: "192.168.0.7"
+    tcp_port: 20108
+    serial_baudrate: 256000
+    serial_port: "/dev/rplidar"
+
+    raw_enabled: true # Enable/Disable raw scan publish
+
+    inverted: false
+    angle_compensate: true
+
+    # Sensitivity: optimized for longer ranger, better sensitivity but weak environment elimination - indoor environment
+    # Boost: optimized for sample rate
+    # Stability: for light elimination performance, but shorter range and lower sample rate - outdoor environment
+    scan_mode: "Stability"
+
+    filter:
+      enabled: false #Enable/Disable filtering and publisher
+      min_range: 0.3
+      check_distance: 10.0
+      scan_search_area: 15
+      minimal_number_of_close_samples: 8
+      minimal_distance_for_acceptance_samples: 0.1

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -20,7 +20,7 @@
     scan_mode: "Stability"
 
     filter:
-      enabled: false #Enable/Disable filtering and publisher
+      enabled: true #Enable/Disable filtering and publisher
       min_range: 0.3
       check_distance: 10.0
       scan_search_area: 15

--- a/config/rplidar.yaml
+++ b/config/rplidar.yaml
@@ -1,7 +1,0 @@
-rplidar:
-  ros__parameters:
-    serial_port: /dev/ttyUSB0
-    serial_baudrate: 115200
-    frame_id: laser_frame
-    inverted: false
-    angle_compensate: true

--- a/config/rplidar_a3.yaml
+++ b/config/rplidar_a3.yaml
@@ -1,7 +1,0 @@
-rplidar:
-  ros__parameters:
-    serial_port: /dev/rplidar
-    serial_baudrate: 256000
-    frame_id: laser_frame
-    inverted: false
-    angle_compensate: true

--- a/config/rplidar_tcp.yaml
+++ b/config/rplidar_tcp.yaml
@@ -1,8 +1,0 @@
-rplidar:
-  ros__parameters:
-    serial_port: /dev/ttyUSB0
-    tcp_ip: '192.168.0.6'
-    tcp_port: 20108
-    frame_id: laser_frame
-    inverted: false
-    angle_compensate: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-# launch file checks env variable SIMULATION and DRONE_TYPE 
-# SIMULATION is by default 0. However, it can be set to 1
-# DRONE_TYPE is by default T-DRONE. However, it can be set to HOLYBRO
-exec ros-with-env ros2 launch rplidar_ros2 sensors_launch.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
-if [ "${SIMULATION+x}" != "" ]; then
-    exec ros-with-env ros2 launch rplidar_ros2 static_tf_launch.py
-else
-    exec ros-with-env ros2 launch rplidar_ros2 sensors_launch.py
-fi
+# launch file checks env variable SIMULATION and DRONE_TYPE 
+# SIMULATION is by default 0. However, it can be set to 1
+# DRONE_TYPE is by default T-DRONE. However, it can be set to HOLYBRO
+exec ros-with-env ros2 launch rplidar_ros2 sensors_launch.py

--- a/include/RPLidarNode.hpp
+++ b/include/RPLidarNode.hpp
@@ -115,9 +115,19 @@ class RPLIDAR_ROS_PUBLIC RPLidarNode : public rclcpp::Node
    bool m_angle_compensate;
    float m_angle_compensate_multiple;
    std::string m_scan_mode;
+   bool m_raw_enabled;
+
+   /* Filtering */
+   bool m_filter_enabled;
+   double m_filter_min_range;
+   double m_filter_check_distance;
+   int m_filter_scan_search_area;
+   int m_filter_minimal_number_of_close_samples;
+   double m_filter_minimal_distance_for_acceptance_samples;
 
    /* Publisher */
-   LaserScanPub m_publisher;
+   LaserScanPub m_publisher_filtered;
+   LaserScanPub m_publisher_raw;
 
    /* Services */
    StopMotorService m_stop_motor_service;

--- a/launch/sensors_launch.py
+++ b/launch/sensors_launch.py
@@ -1,67 +1,88 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import LogInfo
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch.substitutions import ThisLaunchFileDir
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+
+from ament_index_python.packages import get_package_share_directory
+
 import os
 import sys
-
 
 def generate_launch_description():
 
     ld = LaunchDescription()
 
-    # environment variables
+    pkg_name = "rplidar_ros2"
+    pkg_share_path = get_package_share_directory(package_name=pkg_name)
+
+    # Environment variables
     DRONE_DEVICE_ID = os.getenv('DRONE_DEVICE_ID')
+
     # If the SIMULATION environment variable is set to 1, then only static tf publisher will start.
     SIMULATION = os.getenv('SIMULATION')
-
-    # arguments
-    ld.add_action(DeclareLaunchArgument("rplidar_mode", default_value="outdoor"))
-    ld.add_action(DeclareLaunchArgument("serial_port", default_value="/dev/rplidar"))
-
-    # mode select for rplidar
-    # ----------------------
-    # Sensitivity: optimized for longer ranger, better sensitivity but weak environment elimination 
-    # Boost: optimized for sample rate 
-    # Stability: for light elimination performance, but shorter range and lower sample rate 
-    rplidar_mode = PythonExpression(['"Stability" if "outdoor" == "', LaunchConfiguration("rplidar_mode"), '" else "Sensitivity"'])
     simulation_mode = (SIMULATION == "1")
-    #namespace declarations
+
+    DRONE_TYPE = os.getenv('DRONE_TYPE')
+    is_robot_holybro_type = (DRONE_TYPE == "HOLYBRO")
+
+    # Namespace declarations
     namespace = DRONE_DEVICE_ID
 
-    # frame names
+    # Frame names
     fcu_frame = DRONE_DEVICE_ID + "/fcu"         # the same definition is in static_tf_launch.py file
     rplidar_frame = DRONE_DEVICE_ID + "/rplidar" # the same definition is in static_tf_launch.py file
     garmin_frame = DRONE_DEVICE_ID + "/garmin"   # the same definition is in static_tf_launch.py file
 
+    # simulation
+    ld.add_action(
+        LogInfo(msg='--- SIMULATION CONFIGURATION ---', condition=IfCondition(PythonExpression([str(simulation_mode)]))),
+    ),
+    # rplidar driver launch
     ld.add_action(
         Node(
             namespace = namespace,
-            package = 'rplidar_ros2',
+            package = pkg_name,
             executable = 'rplidar',
             condition=IfCondition(PythonExpression(['not ', str(simulation_mode)])),
             name = 'rplidar',
-            parameters = [{
-                'serial_port': LaunchConfiguration("serial_port"),
-                'serial_baudrate': 256000,  # A3
-                'frame_id': rplidar_frame,
-                'inverted': False,
-                'angle_compensate': True,
-                'scan_mode': rplidar_mode,
-                'topic_name': 'rplidar/scan',
-            }],
+            remappings=[
+                # publishers
+                ('topic_filtered_out', '~/scan_filtered'),
+                ('topic_raw_out', '~/scan'),
+            ],
+            parameters = [
+                pkg_share_path + '/config/params.yaml',
+                {"frame_id": rplidar_frame},
+            ],
             output = 'screen',
         ),
     ),
 
+
+    # sensor tf launch
+    ld.add_action(
+        LogInfo(msg='--- HOLYBRO TYPE CONFIGURATION ---', condition=IfCondition(PythonExpression([str(is_robot_holybro_type)]))),
+    ),
     ld.add_action(
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/static_tf_launch.py'])
+            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/static_tf_holybro_launch.py']),
+            condition=IfCondition(PythonExpression([str(is_robot_holybro_type)])),
+        ),
+    ),
+
+    ld.add_action(
+        LogInfo(msg='--- T-DRONE TYPE CONFIGURATION ---', condition=IfCondition(PythonExpression(['not ', str(is_robot_holybro_type)]))),
+    ),
+    ld.add_action(
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/static_tf_tdrone_launch.py']),
+            condition=IfCondition(PythonExpression(['not ', str(is_robot_holybro_type)])),
         ),
     ),
 

--- a/launch/standalone_rplidar_launch.py
+++ b/launch/standalone_rplidar_launch.py
@@ -9,10 +9,15 @@ def generate_launch_description():
             name='rplidar',
             package='rplidar_ros2',
             executable='rplidar',
-            output='screen',
+            remappings=[
+                # publishers
+                ('topic_filtered_out', '~/scan_filtered'),
+                ('topic_raw_out', '~/scan'),
+            ],
             parameters=[
                 path.join(get_package_share_directory('rplidar_ros2'), 'config',
-                          'rplidar_a3.yaml'),
+                          'params.yaml'),
             ],
+            output='screen',
         ),
     ])

--- a/launch/static_tf_holybro_launch.py
+++ b/launch/static_tf_holybro_launch.py
@@ -1,0 +1,44 @@
+from launch import LaunchDescription
+from launch.conditions import IfCondition
+from launch_ros.actions import Node
+import os
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    # environment variables
+    DRONE_DEVICE_ID = os.getenv('DRONE_DEVICE_ID')
+
+    #namespace declarations
+    namespace = DRONE_DEVICE_ID
+
+    # frame names
+    fcu_frame = DRONE_DEVICE_ID + "/fcu"
+    rplidar_frame = DRONE_DEVICE_ID + "/rplidar"
+    garmin_frame = DRONE_DEVICE_ID + "/garmin"
+
+    # node definitions
+    ld.add_action(
+        Node(
+            namespace = namespace,
+            package = "tf2_ros", 
+            executable = "static_transform_publisher",
+            name= "fcu_to_rplidar_static_transform_publisher",
+            arguments = ["0", "0", "0.09", "0", "0", "0", fcu_frame, rplidar_frame],
+            output='screen',
+        ),
+    )
+    
+    ld.add_action(
+        Node(
+            namespace = namespace,
+            package = "tf2_ros", 
+            executable = "static_transform_publisher",
+            name= "fcu_to_garmin_static_transform_publisher",
+            arguments = ["-0.007", "-0.05", "-0.036", "0", "1.5708", "0", fcu_frame, garmin_frame],
+            output='screen',
+        ),
+    )
+
+    return ld

--- a/launch/static_tf_tdrone_launch.py
+++ b/launch/static_tf_tdrone_launch.py
@@ -1,0 +1,44 @@
+from launch import LaunchDescription
+from launch.conditions import IfCondition
+from launch_ros.actions import Node
+import os
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    # environment variables
+    DRONE_DEVICE_ID = os.getenv('DRONE_DEVICE_ID')
+
+    #namespace declarations
+    namespace = DRONE_DEVICE_ID
+
+    # frame names
+    fcu_frame = DRONE_DEVICE_ID + "/fcu"
+    rplidar_frame = DRONE_DEVICE_ID + "/rplidar"
+    garmin_frame = DRONE_DEVICE_ID + "/garmin"
+
+    # node definitions
+    ld.add_action(
+        Node(
+            namespace = namespace,
+            package = "tf2_ros", 
+            executable = "static_transform_publisher",
+            name= "fcu_to_rplidar_static_transform_publisher",
+            arguments = ["-0.078", "0", "0.0614", "3.141592", "0", "0", fcu_frame, rplidar_frame],
+            output='screen',
+        ),
+    )
+    
+    ld.add_action(
+        Node(
+            namespace = namespace,
+            package = "tf2_ros", 
+            executable = "static_transform_publisher",
+            name= "fcu_to_garmin_static_transform_publisher",
+            arguments = ["-0.20", "0", "0.0139", "0", "1.5708", "0", fcu_frame, garmin_frame],
+            output='screen',
+        ),
+    )
+
+    return ld


### PR DESCRIPTION
- Added filtering of the scans (configurable using parameters). The raw scan is now available on the topic `rplidar/scan_raw`. The filtered one is on the topic `rplidar/scan_filtered`
- Added different transform messages for HOLYBRO and T-DRONE platforms. The selection is done using env variable `DRONE_TYPE`. The DRONE_TYPE is by default T-DRONE. However, it can be set to `HOLYBRO`
- Corrected the orientation of the garmin sensor was not right. Now, the sensor is measuring in the direction of the x-axis of the sensor frame, as it is specified for range msg types: https://docs.ros2.org/foxy/api/sensor_msgs/msg/Range.html 
- Added debug printing for configuration using env variables
- Simplified and commented docker `entrypoint.sh`. The `sensor_launch.py` is running only parts that are needed depending on the DRONE_TYPE and SIMULATION settings.

Here you can see two images of tf frames:
HOLYBRO
![Selection_129](https://user-images.githubusercontent.com/7849128/184877330-05d6653e-d9bf-43b2-904c-1af7d80d515e.png)

T-DRONE
![Selection_128](https://user-images.githubusercontent.com/7849128/184877395-2f96fb0b-234f-45c1-a64d-f49d1617467f.png)

