### PR TITLE
Filtered topic option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
 
 COPY . /main_ws/src/
 
@@ -10,7 +10,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
 
 # launch file checks env variables SIMULATION and DRONE_AIRFRAME
 # SIMULATION is by default 0. However, it can be set to 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-7072ebc AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
 
 COPY . /main_ws/src/
 
@@ -10,7 +10,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-7072ebc
+FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
 
 # launch file checks env variables SIMULATION and DRONE_AIRFRAME
 # SIMULATION is by default 0. However, it can be set to 1

--- a/launch/sensors_launch.py
+++ b/launch/sensors_launch.py
@@ -39,6 +39,16 @@ def generate_launch_description():
         print('ERROR: not valid DRONE_AIRFRAME.')
         sys.exit(1)
 
+    # By default use raw scan, only if USE_FILTERED_SCAN is set to 1 or True, use filtered 
+    filtered_name = "~/scan_filtered"
+    raw_name = "~/scan"
+
+    USE_FILTERED_SCAN = os.getenv('USE_FILTERED_SCAN')
+    if(USE_FILTERED_SCAN == "1" or USE_FILTERED_SCAN == "True"):
+        filtered_name = "~/scan"
+        raw_name = "~/scan_unfiltered"
+        print('[INFO] RPLIDAR: using filtered scan.')
+
     # Namespace declarations
     namespace = DRONE_DEVICE_ID
 
@@ -60,9 +70,8 @@ def generate_launch_description():
             condition=IfCondition(PythonExpression(['not ', str(simulation_mode)])),
             name = 'rplidar',
             remappings=[
-                # publishers
-                ('topic_filtered_out', '~/scan_filtered'),
-                ('topic_raw_out', '~/scan'),
+                ('topic_filtered_out', filtered_name),
+                ('topic_raw_out', raw_name),
             ],
             parameters = [
                 pkg_share_path + '/config/params.yaml',

--- a/sdk/include/rplidar_driver.h
+++ b/sdk/include/rplidar_driver.h
@@ -33,7 +33,7 @@
  */
 
 #pragma once
-
+#include <cstddef>
 
 #ifndef __cplusplus
 #error "The RPlidar SDK requires a C++ compiler to be built"

--- a/sdk/src/arch/linux/net_socket.cpp
+++ b/sdk/src/arch/linux/net_socket.cpp
@@ -170,7 +170,7 @@ u_result SocketAddress::getAddressAsString(char * buffer, size_t buffersize) con
 
         break;
     }
-    return ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
+    return ans==NULL?RESULT_OPERATION_FAIL:RESULT_OK;
 }
 
 

--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -1783,10 +1783,10 @@ u_result RPlidarDriverImplCommon::grabScanData(rplidar_response_measurement_node
 
     switch (_dataEvt.wait(timeout))
     {
-    case rp::hal::Event::EVENT_TIMEOUT:
+    case static_cast<unsigned long>(rp::hal::Event::EVENT_TIMEOUT):
         count = 0;
         return RESULT_OPERATION_TIMEOUT;
-    case rp::hal::Event::EVENT_OK:
+    case static_cast<unsigned long>(rp::hal::Event::EVENT_OK):
         {
             if(_cached_scan_node_hq_count == 0) return RESULT_OPERATION_TIMEOUT; //consider as timeout
 
@@ -1812,10 +1812,10 @@ u_result RPlidarDriverImplCommon::grabScanDataHq(rplidar_response_measurement_no
 {
     switch (_dataEvt.wait(timeout))
     {
-    case rp::hal::Event::EVENT_TIMEOUT:
+    case static_cast<unsigned long>(rp::hal::Event::EVENT_TIMEOUT):
         count = 0;
         return RESULT_OPERATION_TIMEOUT;
-    case rp::hal::Event::EVENT_OK:
+    case static_cast<unsigned long>(rp::hal::Event::EVENT_OK):
     {
         if (_cached_scan_node_hq_count == 0) return RESULT_OPERATION_TIMEOUT; //consider as timeout
 


### PR DESCRIPTION
Added env variable USE_FILTERED_SCAN to launch file. When this env is set to 1 or True, it renames the topics such that the filtered scan is named `~/scan` and raw scan `~/scan_unfiltered`. If the variable doesn't exist or is set to anything else, the naming is the same as it was. 

Now it compares string. If you can pass a boolean, the condition can be simplified.