### PR TITLE
Bump tiiuae/fog-ros-baseimage from v3.3.0 to v3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.3.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-926c935-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -14,7 +14,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.3.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c04d413-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.4.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -14,7 +14,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.4.0
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-926c935-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:sha-c04d413-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -14,7 +14,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 # Even though it is possible to tar the install directory for retrieving it later in runtime image,
 # the tar extraction in arm64 emulated on arm64 is still slow. So, we copy the install directory instead
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
 
 HEALTHCHECK --interval=5s \
 	CMD fog-health check --metric=rplidar_scan_count --diff-gte=1.0 \


### PR DESCRIPTION
Update fog-ros-baseimage from sha-c04d413 to v3.4.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**PX4-MSGS Upgraded to v7.0.0**
